### PR TITLE
Add 429 and 500 status code response

### DIFF
--- a/src/Akamai.Common/src/Invoke-AkamaiRestMethod.ps1
+++ b/src/Akamai.Common/src/Invoke-AkamaiRestMethod.ps1
@@ -4,7 +4,7 @@
 
   .DESCRIPTION
   The `Invoke-Akamai RestMethod` cmdlet sends a HTTPS request to Akamai RESTful web services and formats the response based on data type.
-  
+
   When the REST endpoint returns multiple objects, the objects are received as an array. If you pipe the output from `Invoke-AkamaiRestMethod` to another command, it's sent as a single `[Object[]]` object. The contents of that array are not enumerated for the next command on the pipeline.
 
   .PARAMETER Method
@@ -37,10 +37,10 @@
   A variable containing a response headers dictionary. Enter a variable name without the dollar sign `($)` symbol.
 
   .PARAMETER EdgeRCFile
-  The path to an edgerc file. Defaults to `~/.edgerc`. 
+  The path to an edgerc file. Defaults to `~/.edgerc`.
 
   .PARAMETER Section
-  The edgerc section name. Defaults to `default`. 
+  The edgerc section name. Defaults to `default`.
 
   .PARAMETER AccountSwitchKey
   A key used to apply changes to an account external to your credentials' account.
@@ -48,7 +48,7 @@
   .EXAMPLE
   Invoke-AkamaiRestMethod -Method "GET" -Path "/path/to/api"
 
-  `GET` without query parameters. 
+  `GET` without query parameters.
 
   .EXAMPLE
   Invoke-AkamaiRestMethod -Method "POST" -Path "/path/to/api" -Body '{@{"key":{"key2": "value", "key3":"value"}}'
@@ -97,34 +97,34 @@ function Invoke-AkamaiRestMethod {
     Param(
         [Parameter()]
         [ValidateSet("GET", "PUT", "POST", "DELETE", "PATCH")]
-        [string] 
+        [string]
         $Method = "GET",
-        
+
         [Parameter(Mandatory)]
         [string]
         $Path,
 
         [Parameter()]
-        [hashtable] 
+        [hashtable]
         $QueryParameters,
-        
+
         [Parameter()]
-        [hashtable] 
+        [hashtable]
         $AdditionalHeaders,
 
         [Parameter()]
         $Body,
-        
+
         [Parameter()]
-        [string] 
+        [string]
         $InputFile,
 
         [Parameter()]
-        [string] 
+        [string]
         $OutputFile,
 
         [Parameter()]
-        [string] 
+        [string]
         $MaxBody = 131072,
 
         [Parameter()]
@@ -143,14 +143,14 @@ function Invoke-AkamaiRestMethod {
         [string]
         $AccountSwitchKey
     )
-    
+
     # Get auth creds from various potential sources
     $Auth = Get-AkamaiCredentials -EdgeRCFile $EdgeRCFile -Section $Section -AccountSwitchKey $AccountSwitchKey
     if ($Debug) {
         ## Check creds if in Debug mode
         Confirm-Auth -Auth $Auth
     }
-    
+
     # Path with QueryString compatibility
     if ($Path.Contains('?')) {
         $PathElements = $Path.Split('?')
@@ -168,8 +168,8 @@ function Invoke-AkamaiRestMethod {
     if ($QueryFromPath) {
         $QueryString = [System.Web.HttpUtility]::ParseQueryString($QueryFromPath)
         foreach ($key in $QueryString.Keys) {
-            if (@($null, '') -notcontains $key -and @($null, '') -notcontains $QueryString[$key]) { 
-                $QueryNVCollection.Add($key, $QueryString[$key]) 
+            if (@($null, '') -notcontains $key -and @($null, '') -notcontains $QueryString[$key]) {
+                $QueryNVCollection.Add($key, $QueryString[$key])
             }
         }
     }
@@ -190,7 +190,7 @@ function Invoke-AkamaiRestMethod {
     if ($Auth.account_key) {
         $QueryNVCollection.Add('accountSwitchKey', $Auth.account_key)
     }
-    
+
     # Build Request URL
     [System.UriBuilder]$Request = New-Object -TypeName 'System.UriBuilder'
     $Request.Scheme = 'https'
@@ -313,7 +313,7 @@ function Invoke-AkamaiRestMethod {
     else {
         $UserAgent = "AkamaiPowershell/$($Env:AkamaiPowershellVersion) (Powershell $PSEdition $($PSVersionTable.PSVersion) $PSCulture, $($Env:OS))"
     }
-    
+
     # Add headers
     $Headers.Add('Authorization', $AuthorizationHeader)
     $Headers.Add('Accept', 'application/json')
@@ -339,7 +339,7 @@ function Invoke-AkamaiRestMethod {
 
     # Set TLS version to 1.2
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-    
+
     $RequestParameters = @{
         Method             = $Method
         Uri                = $Request.Uri
@@ -347,7 +347,7 @@ function Invoke-AkamaiRestMethod {
         ContentType        = $ContentType
         MaximumRedirection = 0
     }
-    
+
     if ($null -ne $ENV:https_proxy) { $RequestParameters.Proxy = $ENV:https_proxy }
 
     if ($Method -in "PUT", "POST", "PATCH") {
@@ -359,9 +359,9 @@ function Invoke-AkamaiRestMethod {
     if ($PSVersionTable.PSVersion.Major -gt 7 -or ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -ge 4)) {
         $RequestParameters['AllowInsecureRedirect'] = $true
     }
-    
+
     # GET requests typically
-    else { 
+    else {
         # Differentiate on PS 5 and later as PS 5's Invoke-RestMethod doesn't behave the same as the later versions
         if ($PSVersionTable.PSVersion.Major -le 5) {
             $RequestParameters.ErrorAction = "SilentlyContinue"
@@ -394,11 +394,37 @@ function Invoke-AkamaiRestMethod {
                 throw $_
             }
         }
+        elseif ($_.Exception.Response.StatusCode.value__ -eq 429) {
+            $retryAfter = $_.Exception.Response.Headers | Where-Object { $_.Key -eq 'Retry-After' } | Select-Object -ExpandProperty Value
+
+            if ( -not $retryAfter ) {
+                $retryMessage = $_.ErrorDetails.Message | ConvertFrom-Json | Select-Object -ExpandProperty Detail
+                $match = [regex]::Match($retryMessage, 'Retry after: (\d+) seconds')
+                $retryAfter = $match.Groups[1].Value
+            }
+
+            Write-Debug "Rate limited. Waiting $retryAfter seconds"
+            Start-Sleep -Seconds $retryAfter
+
+            $Response = Invoke-AkamaiRestMethod @PSBoundParameters
+        }
+        elseif ($_.Exception.Response.StatusCode.value__ -eq 500) {
+            if ( $script:retryOn500 -le 2 ) {
+
+                $script:retryWaitSec = 20
+                $script:retryOn500++
+
+                Write-Verbose "Sleeping $retryWaitSec and will try again"
+                Start-Sleep -Seconds $retryWaitSec
+
+                $Response = Invoke-AkamaiRestMethod @PSBoundParameters
+            }
+        }
         else {
             throw $_
         }
     }
-    
+
     # PS <5 handling
     if ($null -ne ($Response.PSObject.members | Where-Object { $_.Name -eq "redirectLink" }) -and $method -notin "PUT", "POST", "PATCH") {
         try {
@@ -409,235 +435,10 @@ function Invoke-AkamaiRestMethod {
             throw $_
         }
     }
-    
+
     # Set ResponseHeadersVariable to be passed back to requesting function
     if ($ResponseHeadersVariable) {
         Set-Variable -name $ResponseHeadersVariable -Value (Get-Variable -Name $ResponseHeadersVariable -ValueOnly -ErrorAction SilentlyContinue) -Scope Script
     }
     Return $Response
 }
-# SIG # Begin signature block
-# MIIpogYJKoZIhvcNAQcCoIIpkzCCKY8CAQExDzANBglghkgBZQMEAgEFADB5Bgor
-# BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG
-# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCC4QmPf4tPTXnY8
-# a3q4woaa40gdQ8H1Dy56Lwv1fF+vvKCCDo4wggawMIIEmKADAgECAhAIrUCyYNKc
-# TJ9ezam9k67ZMA0GCSqGSIb3DQEBDAUAMGIxCzAJBgNVBAYTAlVTMRUwEwYDVQQK
-# EwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xITAfBgNV
-# BAMTGERpZ2lDZXJ0IFRydXN0ZWQgUm9vdCBHNDAeFw0yMTA0MjkwMDAwMDBaFw0z
-# NjA0MjgyMzU5NTlaMGkxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5EaWdpQ2VydCwg
-# SW5jLjFBMD8GA1UEAxM4RGlnaUNlcnQgVHJ1c3RlZCBHNCBDb2RlIFNpZ25pbmcg
-# UlNBNDA5NiBTSEEzODQgMjAyMSBDQTEwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
-# ggIKAoICAQDVtC9C0CiteLdd1TlZG7GIQvUzjOs9gZdwxbvEhSYwn6SOaNhc9es0
-# JAfhS0/TeEP0F9ce2vnS1WcaUk8OoVf8iJnBkcyBAz5NcCRks43iCH00fUyAVxJr
-# Q5qZ8sU7H/Lvy0daE6ZMswEgJfMQ04uy+wjwiuCdCcBlp/qYgEk1hz1RGeiQIXhF
-# LqGfLOEYwhrMxe6TSXBCMo/7xuoc82VokaJNTIIRSFJo3hC9FFdd6BgTZcV/sk+F
-# LEikVoQ11vkunKoAFdE3/hoGlMJ8yOobMubKwvSnowMOdKWvObarYBLj6Na59zHh
-# 3K3kGKDYwSNHR7OhD26jq22YBoMbt2pnLdK9RBqSEIGPsDsJ18ebMlrC/2pgVItJ
-# wZPt4bRc4G/rJvmM1bL5OBDm6s6R9b7T+2+TYTRcvJNFKIM2KmYoX7BzzosmJQay
-# g9Rc9hUZTO1i4F4z8ujo7AqnsAMrkbI2eb73rQgedaZlzLvjSFDzd5Ea/ttQokbI
-# YViY9XwCFjyDKK05huzUtw1T0PhH5nUwjewwk3YUpltLXXRhTT8SkXbev1jLchAp
-# QfDVxW0mdmgRQRNYmtwmKwH0iU1Z23jPgUo+QEdfyYFQc4UQIyFZYIpkVMHMIRro
-# OBl8ZhzNeDhFMJlP/2NPTLuqDQhTQXxYPUez+rbsjDIJAsxsPAxWEQIDAQABo4IB
-# WTCCAVUwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUaDfg67Y7+F8Rhvv+
-# YXsIiGX0TkIwHwYDVR0jBBgwFoAU7NfjgtJxXWRM3y5nP+e6mK4cD08wDgYDVR0P
-# AQH/BAQDAgGGMBMGA1UdJQQMMAoGCCsGAQUFBwMDMHcGCCsGAQUFBwEBBGswaTAk
-# BggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQuY29tMEEGCCsGAQUFBzAC
-# hjVodHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNlcnRUcnVzdGVkUm9v
-# dEc0LmNydDBDBgNVHR8EPDA6MDigNqA0hjJodHRwOi8vY3JsMy5kaWdpY2VydC5j
-# b20vRGlnaUNlcnRUcnVzdGVkUm9vdEc0LmNybDAcBgNVHSAEFTATMAcGBWeBDAED
-# MAgGBmeBDAEEATANBgkqhkiG9w0BAQwFAAOCAgEAOiNEPY0Idu6PvDqZ01bgAhql
-# +Eg08yy25nRm95RysQDKr2wwJxMSnpBEn0v9nqN8JtU3vDpdSG2V1T9J9Ce7FoFF
-# UP2cvbaF4HZ+N3HLIvdaqpDP9ZNq4+sg0dVQeYiaiorBtr2hSBh+3NiAGhEZGM1h
-# mYFW9snjdufE5BtfQ/g+lP92OT2e1JnPSt0o618moZVYSNUa/tcnP/2Q0XaG3Ryw
-# YFzzDaju4ImhvTnhOE7abrs2nfvlIVNaw8rpavGiPttDuDPITzgUkpn13c5Ubdld
-# AhQfQDN8A+KVssIhdXNSy0bYxDQcoqVLjc1vdjcshT8azibpGL6QB7BDf5WIIIJw
-# 8MzK7/0pNVwfiThV9zeKiwmhywvpMRr/LhlcOXHhvpynCgbWJme3kuZOX956rEnP
-# LqR0kq3bPKSchh/jwVYbKyP/j7XqiHtwa+aguv06P0WmxOgWkVKLQcBIhEuWTatE
-# QOON8BUozu3xGFYHKi8QxAwIZDwzj64ojDzLj4gLDb879M4ee47vtevLt/B3E+bn
-# KD+sEq6lLyJsQfmCXBVmzGwOysWGw/YmMwwHS6DTBwJqakAwSEs0qFEgu60bhQji
-# WQ1tygVQK+pKHJ6l/aCnHwZ05/LWUpD9r4VIIflXO7ScA+2GRfS0YW6/aOImYIbq
-# yK+p/pQd52MbOoZWeE4wggfWMIIFvqADAgECAhAPdHYvm0RfSrL6EenUiisxMA0G
-# CSqGSIb3DQEBCwUAMGkxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5EaWdpQ2VydCwg
-# SW5jLjFBMD8GA1UEAxM4RGlnaUNlcnQgVHJ1c3RlZCBHNCBDb2RlIFNpZ25pbmcg
-# UlNBNDA5NiBTSEEzODQgMjAyMSBDQTEwHhcNMjQwMzE1MDAwMDAwWhcNMjUwMzAy
-# MjM1OTU5WjCB3jETMBEGCysGAQQBgjc8AgEDEwJVUzEZMBcGCysGAQQBgjc8AgEC
-# EwhEZWxhd2FyZTEdMBsGA1UEDwwUUHJpdmF0ZSBPcmdhbml6YXRpb24xEDAOBgNV
-# BAUTBzI5MzM2MzcxCzAJBgNVBAYTAlVTMRYwFAYDVQQIEw1NYXNzYWNodXNldHRz
-# MRIwEAYDVQQHEwlDYW1icmlkZ2UxIDAeBgNVBAoTF0FrYW1haSBUZWNobm9sb2dp
-# ZXMgSW5jMSAwHgYDVQQDExdBa2FtYWkgVGVjaG5vbG9naWVzIEluYzCCAiIwDQYJ
-# KoZIhvcNAQEBBQADggIPADCCAgoCggIBAMKT63Qf7DusoLBOT9oEXEoDEvodyW3S
-# +cpx3iPUcL06mhVej3PzKO/O+cFRHIoM3VAWbU/68bsIBJJPQR7E40v5OIBaEM/H
-# NCKMzSzdsOajaKS88f6KOD4FJlgqhpHXx0qPCOlDsbal8260KYbg/9rR1elhP90L
-# xjcq6S7Ns2NnPXj4RrEf7XV+S7jbsbX0pR4BvzYilmiavYrbu0u357+mJPddDp+I
-# /yZSmVEJAcXwqXqO1YbwwWY6B1QL34Qd2gmcb3dRjC7MFVNIDREAawsPDFztmoyE
-# FveD4TNwD3klQcC//tzHELCCN6cQN2w3+NrxAgCJOpcdqgdAWiPkHtp5DJttPMLq
-# 8OUoCC0352Sj74JyaHbu8Znm4M0M1haQEogItbD4xU+ceNwFJJcOa2vAXP0CEMNI
-# STLDLUEFWrhYWbu0RBsN1l5NWUhrlhRWjPkf8tWxLicmpF7YpkzWKSiPCyURmx4B
-# kj1xHnMDWx9jjDqznUGzHgNtm8bE53DayRtEeYAp9NvyKSgmCSWwHrjMxI537WPs
-# YHnjanskm0o0Dt/RyeHCoF+im+nKrnukAjIexWUGFnzDL2Pe9OPNBFGSwfzWwrUp
-# WBwXq/mJe+aqb2vb1jMYTi3YiqfFBi1YKYtUYlQjrdjMoF/hLw87Yqf+Zx74xYOx
-# 8e7DUgFCE+klAgMBAAGjggICMIIB/jAfBgNVHSMEGDAWgBRoN+Drtjv4XxGG+/5h
-# ewiIZfROQjAdBgNVHQ4EFgQU97GBfkNk6mU8S+SGvccldFp0jxUwPQYDVR0gBDYw
-# NDAyBgVngQwBAzApMCcGCCsGAQUFBwIBFhtodHRwOi8vd3d3LmRpZ2ljZXJ0LmNv
-# bS9DUFMwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMIG1BgNV
-# HR8Ega0wgaowU6BRoE+GTWh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2Vy
-# dFRydXN0ZWRHNENvZGVTaWduaW5nUlNBNDA5NlNIQTM4NDIwMjFDQTEuY3JsMFOg
-# UaBPhk1odHRwOi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRUcnVzdGVkRzRD
-# b2RlU2lnbmluZ1JTQTQwOTZTSEEzODQyMDIxQ0ExLmNybDCBlAYIKwYBBQUHAQEE
-# gYcwgYQwJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBcBggr
-# BgEFBQcwAoZQaHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VHJ1
-# c3RlZEc0Q29kZVNpZ25pbmdSU0E0MDk2U0hBMzg0MjAyMUNBMS5jcnQwCQYDVR0T
-# BAIwADANBgkqhkiG9w0BAQsFAAOCAgEAsrjp8fupvxd4TgwbABuZJzP7nXHNcI9E
-# eoz/Oqx+00AqTs8grcueY3bLcg2Za7HwqTZVy45758027dK32Uoz98TWKg2e4OM0
-# OKoDolbJI8Akx91Qi6+f4ayziNrdcxm0SIdsYNo4lR4jhrQojCHgNA+e/5x94ltE
-# k0kS8PLLN1NiuFFtkMBP+2X3HCnaA2tt2XR6lbuUXq8B+8OZzlSuyjviT7EhTYcb
-# 9B3frETSZ0MwyhQG3HqxIZLvvWF8n3gwfITkQ0B4NRkVW8spKPn2apHkvLM53mJr
-# UMXGhDeJySEm009xeZ61HZ1kGZbL3XlqdrzCcLVFZBmpqtw9FSbmomhBAstBWgpA
-# B3MpM3Btj1McKyU1846ZboDiWmsd/urHXU7I5v3xAYvqTL7CN5oWfZnHaBFJUFMo
-# Zc325j1pLqcJUkszLDPI1IOW7LQAdIjGhfYcpLwkjFgxkmWmRKzR8ONIQRQI8cIU
-# uisYDKWvYyipHVLeVxinH6rCoCrZx9FSPwvKpxK9CYWkw4Jd0Hhf/u+j3xBJIusd
-# JzgyKhAt/DHa9UG1/IpJsUkx9eb1I+aRASX/oBXGQtKPyDSUPOMThZc9j55Z4wp0
-# g/7WqD4KbJQ04xFBEE/gGstFej2+onuZ6cD9v7/drgX4IjbDlgrzHiWJaZojJhF3
-# RJ9rC09tn8QxghpqMIIaZgIBATB9MGkxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5E
-# aWdpQ2VydCwgSW5jLjFBMD8GA1UEAxM4RGlnaUNlcnQgVHJ1c3RlZCBHNCBDb2Rl
-# IFNpZ25pbmcgUlNBNDA5NiBTSEEzODQgMjAyMSBDQTECEA90di+bRF9KsvoR6dSK
-# KzEwDQYJYIZIAWUDBAIBBQCgfDAQBgorBgEEAYI3AgEMMQIwADAZBgkqhkiG9w0B
-# CQMxDAYKKwYBBAGCNwIBBDAcBgorBgEEAYI3AgELMQ4wDAYKKwYBBAGCNwIBFTAv
-# BgkqhkiG9w0BCQQxIgQg5GgBT1qMDhKspFCw1kR/VUDANUi52KNO5/2WKjOsgKAw
-# DQYJKoZIhvcNAQEBBQAEggIAdBjfutimZ3dPSEZupchYWm+g8S2j9ZDIkXl3O2xd
-# HT0NX1W2+m8Qb9fNf5mzD5U5O/prTAQV6k7fqUA734Oja5PVC9UBNP1t8Yaii5rH
-# /N8zdYJPzD/+X1eOfYcINe94JrDnTdvDwAfIXYK3jNXRSLNlvwFRK/JKxx6idynK
-# 3gub82Od5GWFYtZmWdO0vQxSGj23+XQtuAa7Lp8lwU5RX7t/XdX2aI0D83mos3qG
-# aGiNHuxxR7rajU7kEjzL1DnkyBYwQD1/JwJ6VOMV/JDn7dFzPzRiLLLPOdmrKi7s
-# kbv9Ztv76H7gKwWMdtmlx8O3q5YrktAscY37mwNVXC1LUmHnm73PnsGHGJwkiGng
-# wC2f2X6D91eYg7uqE+3Nl2BUSNcxpVGlkiKgXiQyJwGQER2XQ6owY+qN17wSTZ1D
-# yO09QTy61Nx0ULt0J9zUWnwQFIFc4Iv0caeL9KRluQuYy772sXWzaQ81PUcPLQTR
-# ByYCsb+z0xzHmf8zRiPvTFzJeFpsk5Q5L1h5chngGsa9BXltLAoxJ0qY2GhRddeb
-# UrVjvwUWpLBi6GuI/AalbrfyHzi/GQ8KjbHh3rS1Jt2YlxjNWutO/6kzB35akCcT
-# AeDgfVxamBz15dCpQlPueEA5nmUXXMymbn7rVD8M8tTePA3w2vhlorkWxkEMERG7
-# t0ahghdAMIIXPAYKKwYBBAGCNwMDATGCFywwghcoBgkqhkiG9w0BBwKgghcZMIIX
-# FQIBAzEPMA0GCWCGSAFlAwQCAQUAMHgGCyqGSIb3DQEJEAEEoGkEZzBlAgEBBglg
-# hkgBhv1sBwEwMTANBglghkgBZQMEAgEFAAQg5hXe+hg8iKhshnbojsItdEW/0Q/p
-# 4kXIZbH5/p+vFqECEQCCv7txwySuge8hyof2db3uGA8yMDI0MDQxMTE1MjgxMlqg
-# ghMJMIIGwjCCBKqgAwIBAgIQBUSv85SdCDmmv9s/X+VhFjANBgkqhkiG9w0BAQsF
-# ADBjMQswCQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xOzA5BgNV
-# BAMTMkRpZ2lDZXJ0IFRydXN0ZWQgRzQgUlNBNDA5NiBTSEEyNTYgVGltZVN0YW1w
-# aW5nIENBMB4XDTIzMDcxNDAwMDAwMFoXDTM0MTAxMzIzNTk1OVowSDELMAkGA1UE
-# BhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJbmMuMSAwHgYDVQQDExdEaWdpQ2Vy
-# dCBUaW1lc3RhbXAgMjAyMzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
-# AKNTRYcdg45brD5UsyPgz5/X5dLnXaEOCdwvSKOXejsqnGfcYhVYwamTEafNqrJq
-# 3RApih5iY2nTWJw1cb86l+uUUI8cIOrHmjsvlmbjaedp/lvD1isgHMGXlLSlUIHy
-# z8sHpjBoyoNC2vx/CSSUpIIa2mq62DvKXd4ZGIX7ReoNYWyd/nFexAaaPPDFLnkP
-# G2ZS48jWPl/aQ9OE9dDH9kgtXkV1lnX+3RChG4PBuOZSlbVH13gpOWvgeFmX40Qr
-# StWVzu8IF+qCZE3/I+PKhu60pCFkcOvV5aDaY7Mu6QXuqvYk9R28mxyyt1/f8O52
-# fTGZZUdVnUokL6wrl76f5P17cz4y7lI0+9S769SgLDSb495uZBkHNwGRDxy1Uc2q
-# TGaDiGhiu7xBG3gZbeTZD+BYQfvYsSzhUa+0rRUGFOpiCBPTaR58ZE2dD9/O0V6M
-# qqtQFcmzyrzXxDtoRKOlO0L9c33u3Qr/eTQQfqZcClhMAD6FaXXHg2TWdc2PEnZW
-# pST618RrIbroHzSYLzrqawGw9/sqhux7UjipmAmhcbJsca8+uG+W1eEQE/5hRwqM
-# /vC2x9XH3mwk8L9CgsqgcT2ckpMEtGlwJw1Pt7U20clfCKRwo+wK8REuZODLIivK
-# 8SgTIUlRfgZm0zu++uuRONhRB8qUt+JQofM604qDy0B7AgMBAAGjggGLMIIBhzAO
-# BgNVHQ8BAf8EBAMCB4AwDAYDVR0TAQH/BAIwADAWBgNVHSUBAf8EDDAKBggrBgEF
-# BQcDCDAgBgNVHSAEGTAXMAgGBmeBDAEEAjALBglghkgBhv1sBwEwHwYDVR0jBBgw
-# FoAUuhbZbU2FL3MpdpovdYxqII+eyG8wHQYDVR0OBBYEFKW27xPn783QZKHVVqll
-# MaPe1eNJMFoGA1UdHwRTMFEwT6BNoEuGSWh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNv
-# bS9EaWdpQ2VydFRydXN0ZWRHNFJTQTQwOTZTSEEyNTZUaW1lU3RhbXBpbmdDQS5j
-# cmwwgZAGCCsGAQUFBwEBBIGDMIGAMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5k
-# aWdpY2VydC5jb20wWAYIKwYBBQUHMAKGTGh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0
-# LmNvbS9EaWdpQ2VydFRydXN0ZWRHNFJTQTQwOTZTSEEyNTZUaW1lU3RhbXBpbmdD
-# QS5jcnQwDQYJKoZIhvcNAQELBQADggIBAIEa1t6gqbWYF7xwjU+KPGic2CX/yyzk
-# zepdIpLsjCICqbjPgKjZ5+PF7SaCinEvGN1Ott5s1+FgnCvt7T1IjrhrunxdvcJh
-# N2hJd6PrkKoS1yeF844ektrCQDifXcigLiV4JZ0qBXqEKZi2V3mP2yZWK7Dzp703
-# DNiYdk9WuVLCtp04qYHnbUFcjGnRuSvExnvPnPp44pMadqJpddNQ5EQSviANnqlE
-# 0PjlSXcIWiHFtM+YlRpUurm8wWkZus8W8oM3NG6wQSbd3lqXTzON1I13fXVFoaVY
-# JmoDRd7ZULVQjK9WvUzF4UbFKNOt50MAcN7MmJ4ZiQPq1JE3701S88lgIcRWR+3a
-# EUuMMsOI5ljitts++V+wQtaP4xeR0arAVeOGv6wnLEHQmjNKqDbUuXKWfpd5OEhf
-# ysLcPTLfddY2Z1qJ+Panx+VPNTwAvb6cKmx5AdzaROY63jg7B145WPR8czFVoIAR
-# yxQMfq68/qTreWWqaNYiyjvrmoI1VygWy2nyMpqy0tg6uLFGhmu6F/3Ed2wVbK6r
-# r3M66ElGt9V/zLY4wNjsHPW2obhDLN9OTH0eaHDAdwrUAuBcYLso/zjlUlrWrBci
-# I0707NMX+1Br/wd3H3GXREHJuEbTbDJ8WC9nR2XlG3O2mflrLAZG70Ee8PBf4NvZ
-# rZCARK+AEEGKMIIGrjCCBJagAwIBAgIQBzY3tyRUfNhHrP0oZipeWzANBgkqhkiG
-# 9w0BAQsFADBiMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkw
-# FwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSEwHwYDVQQDExhEaWdpQ2VydCBUcnVz
-# dGVkIFJvb3QgRzQwHhcNMjIwMzIzMDAwMDAwWhcNMzcwMzIyMjM1OTU5WjBjMQsw
-# CQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xOzA5BgNVBAMTMkRp
-# Z2lDZXJ0IFRydXN0ZWQgRzQgUlNBNDA5NiBTSEEyNTYgVGltZVN0YW1waW5nIENB
-# MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxoY1BkmzwT1ySVFVxyUD
-# xPKRN6mXUaHW0oPRnkyibaCwzIP5WvYRoUQVQl+kiPNo+n3znIkLf50fng8zH1AT
-# CyZzlm34V6gCff1DtITaEfFzsbPuK4CEiiIY3+vaPcQXf6sZKz5C3GeO6lE98NZW
-# 1OcoLevTsbV15x8GZY2UKdPZ7Gnf2ZCHRgB720RBidx8ald68Dd5n12sy+iEZLRS
-# 8nZH92GDGd1ftFQLIWhuNyG7QKxfst5Kfc71ORJn7w6lY2zkpsUdzTYNXNXmG6jB
-# ZHRAp8ByxbpOH7G1WE15/tePc5OsLDnipUjW8LAxE6lXKZYnLvWHpo9OdhVVJnCY
-# Jn+gGkcgQ+NDY4B7dW4nJZCYOjgRs/b2nuY7W+yB3iIU2YIqx5K/oN7jPqJz+ucf
-# WmyU8lKVEStYdEAoq3NDzt9KoRxrOMUp88qqlnNCaJ+2RrOdOqPVA+C/8KI8ykLc
-# GEh/FDTP0kyr75s9/g64ZCr6dSgkQe1CvwWcZklSUPRR8zZJTYsg0ixXNXkrqPNF
-# YLwjjVj33GHek/45wPmyMKVM1+mYSlg+0wOI/rOP015LdhJRk8mMDDtbiiKowSYI
-# +RQQEgN9XyO7ZONj4KbhPvbCdLI/Hgl27KtdRnXiYKNYCQEoAA6EVO7O6V3IXjAS
-# vUaetdN2udIOa5kM0jO0zbECAwEAAaOCAV0wggFZMBIGA1UdEwEB/wQIMAYBAf8C
-# AQAwHQYDVR0OBBYEFLoW2W1NhS9zKXaaL3WMaiCPnshvMB8GA1UdIwQYMBaAFOzX
-# 44LScV1kTN8uZz/nupiuHA9PMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAKBggr
-# BgEFBQcDCDB3BggrBgEFBQcBAQRrMGkwJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3Nw
-# LmRpZ2ljZXJ0LmNvbTBBBggrBgEFBQcwAoY1aHR0cDovL2NhY2VydHMuZGlnaWNl
-# cnQuY29tL0RpZ2lDZXJ0VHJ1c3RlZFJvb3RHNC5jcnQwQwYDVR0fBDwwOjA4oDag
-# NIYyaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VHJ1c3RlZFJvb3RH
-# NC5jcmwwIAYDVR0gBBkwFzAIBgZngQwBBAIwCwYJYIZIAYb9bAcBMA0GCSqGSIb3
-# DQEBCwUAA4ICAQB9WY7Ak7ZvmKlEIgF+ZtbYIULhsBguEE0TzzBTzr8Y+8dQXeJL
-# Kftwig2qKWn8acHPHQfpPmDI2AvlXFvXbYf6hCAlNDFnzbYSlm/EUExiHQwIgqgW
-# valWzxVzjQEiJc6VaT9Hd/tydBTX/6tPiix6q4XNQ1/tYLaqT5Fmniye4Iqs5f2M
-# vGQmh2ySvZ180HAKfO+ovHVPulr3qRCyXen/KFSJ8NWKcXZl2szwcqMj+sAngkSu
-# mScbqyQeJsG33irr9p6xeZmBo1aGqwpFyd/EjaDnmPv7pp1yr8THwcFqcdnGE4AJ
-# xLafzYeHJLtPo0m5d2aR8XKc6UsCUqc3fpNTrDsdCEkPlM05et3/JWOZJyw9P2un
-# 8WbDQc1PtkCbISFA0LcTJM3cHXg65J6t5TRxktcma+Q4c6umAU+9Pzt4rUyt+8SV
-# e+0KXzM5h0F4ejjpnOHdI/0dKNPH+ejxmF/7K9h+8kaddSweJywm228Vex4Ziza4
-# k9Tm8heZWcpw8De/mADfIBZPJ/tgZxahZrrdVcA6KYawmKAr7ZVBtzrVFZgxtGIJ
-# Dwq9gdkT/r+k0fNX2bwE+oLeMt8EifAAzV3C+dAjfwAL5HYCJtnwZXZCpimHCUcr
-# 5n8apIUP/JiW9lVUKx+A+sDyDivl1vupL0QVSucTDh3bNzgaoSv27dZ8/DCCBY0w
-# ggR1oAMCAQICEA6bGI750C3n79tQ4ghAGFowDQYJKoZIhvcNAQEMBQAwZTELMAkG
-# A1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3LmRp
-# Z2ljZXJ0LmNvbTEkMCIGA1UEAxMbRGlnaUNlcnQgQXNzdXJlZCBJRCBSb290IENB
-# MB4XDTIyMDgwMTAwMDAwMFoXDTMxMTEwOTIzNTk1OVowYjELMAkGA1UEBhMCVVMx
-# FTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3LmRpZ2ljZXJ0LmNv
-# bTEhMB8GA1UEAxMYRGlnaUNlcnQgVHJ1c3RlZCBSb290IEc0MIICIjANBgkqhkiG
-# 9w0BAQEFAAOCAg8AMIICCgKCAgEAv+aQc2jeu+RdSjwwIjBpM+zCpyUuySE98orY
-# WcLhKac9WKt2ms2uexuEDcQwH/MbpDgW61bGl20dq7J58soR0uRf1gU8Ug9SH8ae
-# FaV+vp+pVxZZVXKvaJNwwrK6dZlqczKU0RBEEC7fgvMHhOZ0O21x4i0MG+4g1ckg
-# HWMpLc7sXk7Ik/ghYZs06wXGXuxbGrzryc/NrDRAX7F6Zu53yEioZldXn1RYjgwr
-# t0+nMNlW7sp7XeOtyU9e5TXnMcvak17cjo+A2raRmECQecN4x7axxLVqGDgDEI3Y
-# 1DekLgV9iPWCPhCRcKtVgkEy19sEcypukQF8IUzUvK4bA3VdeGbZOjFEmjNAvwjX
-# WkmkwuapoGfdpCe8oU85tRFYF/ckXEaPZPfBaYh2mHY9WV1CdoeJl2l6SPDgohIb
-# Zpp0yt5LHucOY67m1O+SkjqePdwA5EUlibaaRBkrfsCUtNJhbesz2cXfSwQAzH0c
-# lcOP9yGyshG3u3/y1YxwLEFgqrFjGESVGnZifvaAsPvoZKYz0YkH4b235kOkGLim
-# dwHhD5QMIR2yVCkliWzlDlJRR3S+Jqy2QXXeeqxfjT/JvNNBERJb5RBQ6zHFynIW
-# IgnffEx1P2PsIV/EIFFrb7GrhotPwtZFX50g/KEexcCPorF+CiaZ9eRpL5gdLfXZ
-# qbId5RsCAwEAAaOCATowggE2MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOzX
-# 44LScV1kTN8uZz/nupiuHA9PMB8GA1UdIwQYMBaAFEXroq/0ksuCMS1Ri6enIZ3z
-# bcgPMA4GA1UdDwEB/wQEAwIBhjB5BggrBgEFBQcBAQRtMGswJAYIKwYBBQUHMAGG
-# GGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBDBggrBgEFBQcwAoY3aHR0cDovL2Nh
-# Y2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0QXNzdXJlZElEUm9vdENBLmNydDBF
-# BgNVHR8EPjA8MDqgOKA2hjRodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vRGlnaUNl
-# cnRBc3N1cmVkSURSb290Q0EuY3JsMBEGA1UdIAQKMAgwBgYEVR0gADANBgkqhkiG
-# 9w0BAQwFAAOCAQEAcKC/Q1xV5zhfoKN0Gz22Ftf3v1cHvZqsoYcs7IVeqRq7IviH
-# GmlUIu2kiHdtvRoU9BNKei8ttzjv9P+Aufih9/Jy3iS8UgPITtAq3votVs/59Pes
-# MHqai7Je1M/RQ0SbQyHrlnKhSLSZy51PpwYDE3cnRNTnf+hZqPC/Lwum6fI0POz3
-# A8eHqNJMQBk1RmppVLC4oVaO7KTVPeix3P0c2PR3WlxUjG/voVA9/HYJaISfb8rb
-# II01YBwCA8sgsKxYoA5AY8WYIsGyWfVVa88nq2x2zm8jLfR+cWojayL/ErhULSd+
-# 2DrZ8LaHlv1b0VysGMNNn3O3AamfV6peKOK5lDGCA3YwggNyAgEBMHcwYzELMAkG
-# A1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJbmMuMTswOQYDVQQDEzJEaWdp
-# Q2VydCBUcnVzdGVkIEc0IFJTQTQwOTYgU0hBMjU2IFRpbWVTdGFtcGluZyBDQQIQ
-# BUSv85SdCDmmv9s/X+VhFjANBglghkgBZQMEAgEFAKCB0TAaBgkqhkiG9w0BCQMx
-# DQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTI0MDQxMTE1MjgxMlowKwYL
-# KoZIhvcNAQkQAgwxHDAaMBgwFgQUZvArMsLCyQ+CXc6qisnGTxmcz0AwLwYJKoZI
-# hvcNAQkEMSIEILdfMyitfonTX0FsySMoTBYPI9whGdPusloQkbs20BXBMDcGCyqG
-# SIb3DQEJEAIvMSgwJjAkMCIEINL25G3tdCLM0dRAV2hBNm+CitpVmq4zFq9NGprU
-# DHgoMA0GCSqGSIb3DQEBAQUABIICADD9g7ho6dzZ7wGxnuycGtOwP3Z6kOs4TobJ
-# lVWs4+toAey6a06LyPwMtY6MWYJpeDYTdm55HvEVrZYNdsOxc95ssH1YGYqxXFi/
-# JE89v0MDC+as9AVbl3lhOOjYNE3t7zcyqgZlSWgVXnqQOrk2ADiYS65IxvZINQl8
-# ihrgMhevpo80IY0UgfQSPik1YCksxy98XuYJduxtIgRlZzGLNc6NQqKqCMmgE4Vu
-# NqYJkdROPvTmupofSek9e8AG0id/K/8ZvIe7HEWU8GizjPwLnamuE/rGUZbZoogT
-# qiD8BPaMvjYn6lKI5mO3KUvEPWkLfvc5QZcDoO/gSqtO70hoYX7pFrGPuonLQ2D9
-# kdBaH+HmNGbBGr/pxid/EDB4R70X678iR7bzfCqE6KTCEAJRzx6Ur5zjVh4SkXtB
-# YXNlA9sPqpkmb4XLFPFZE2YCZUuKo1n55oI0egIyxJLqdMcsf0/Vj7sKqjiUlWwa
-# UPU519DMo4/5p1eP+AFnScI+a1Z7LYDg+2RyWIugO9ZB8AN91fTw2BKN8eQa61Km
-# b79zgdpvn6/iFrtx6mVFYXNQsqnW8g9Hcr+Q8PdNogBRYOoq3jn9dx1HoJWDcV+x
-# WhQdDrrRuIyjYMg45NguKvMU97EKUWwoNG2/LCNtMP3ZEwWdpZWm4h2phiz64OZT
-# fl1tSdkR
-# SIG # End signature block


### PR DESCRIPTION
Venafi has found at times that we get 429: Too Many Requests and random 500 responses. I have added to the Invoke-AkamaiRestMethod function code to handle this.
Note: This code was added to our scripts by Greg Brownstein (https://github.com/gdbarron).